### PR TITLE
AES example key expansion correction

### DIFF
--- a/features/aes_hash_crypto/src/main.c
+++ b/features/aes_hash_crypto/src/main.c
@@ -400,6 +400,7 @@ static void prvAES_CBC_128_NON_FRAG_DATA( void *pvParameters )
 #if (dg_configAES_USE_OTP_KEYS == 1)
                 hw_aes_otp_keys_load(HW_AES_128, key_otp);
 #else
+                hw_aes_set_key_expansion(HW_AES_KEY_EXPAND_BY_HW);
                 hw_aes_load_keys((uint32_t)key_otp, HW_AES_KEY_SIZE_128, HW_AES_KEY_EXPAND_BY_HW);
 #endif //#if (dg_configAES_USE_OTP_KEYS == 1)
 
@@ -515,6 +516,7 @@ static void prvAES_CBC_256_NON_FRAG_DATA(void *pvParameters)
 #if (dg_configAES_USE_OTP_KEYS == 1)
                 hw_aes_otp_keys_load(HW_AES_256, key_otp);
 #else
+                hw_aes_set_key_expansion(HW_AES_KEY_EXPAND_BY_HW);
                 hw_aes_load_keys((uint32_t)key_otp, HW_AES_KEY_SIZE_256, HW_AES_KEY_EXPAND_BY_HW);
 #endif //#if (dg_configAES_USE_OTP_KEYS == 1)
                 /* ------------------------------------------------------ Encryption process ------------------------------------------------- */
@@ -638,6 +640,7 @@ static void prvAES_CTR_192_FRAG_DATA( void *pvParameters )
                #if (dg_configAES_USE_OTP_KEYS == 1)
                 hw_aes_otp_keys_load(HW_AES_192, key_otp);
 #else
+                hw_aes_set_key_expansion(HW_AES_KEY_EXPAND_BY_HW);
                 hw_aes_load_keys((uint32_t)key_otp, HW_AES_KEY_SIZE_192, HW_AES_KEY_EXPAND_BY_HW);
 #endif //#if (dg_configAES_USE_OTP_KEYS == 1)
 


### PR DESCRIPTION
The AES key expansion API is changed in 10.0.12 and requires changes in the aes_encryption example to be functional